### PR TITLE
fix case typos for commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ for myself.
 
 Writegood.vim introduces three commands to enable, disable, or toggle its functionality:
 
-* `:WriteGoodEnable`
-* `:WriteGoodDisable`
-* `:WriteGoodToggle`
+* `:WritegoodEnable`
+* `:WritegoodDisable`
+* `:WritegoodToggle`
 
 ### Links
 * Matt Might's original [blog post](http://matt.might.net/articles/shell-scripts-for-passive-voice-weasel-words-duplicates/)


### PR DESCRIPTION
So they match what is defined in https://github.com/davidbeckingsale/writegood.vim/blob/master/plugin/writegood.vim#L26-L28.

Btw, thanks for the tool.