### PR TITLE
Make the duplication check case insensitive

### DIFF
--- a/autoload/writegood.vim
+++ b/autoload/writegood.vim
@@ -49,7 +49,7 @@ endfunction!
 " Pattern for highlighting duplicate words, works across lines.
 "
 function writegood#highlight_dups()
-    let s:dups=matchadd('Error', '\v(<\w+>)\_s*<\1>', 10)
+    let s:dups=matchadd('Error', '\c\v(<\w+>)\_s*<\1>', 10)
 endfunction
 
 "


### PR DESCRIPTION
For some reason I managed to type 'This this' at the start of a
sentence and I noticed that this wasn't picked up as a duplicate.
This minor change makes that happen!